### PR TITLE
fix load_parameters for array precision and atom_shape

### DIFF
--- a/src/cryolike/microscopy/parameters.py
+++ b/src/cryolike/microscopy/parameters.py
@@ -207,14 +207,14 @@ def load_parameters(file_output: str) -> ParsedParameters:
         radii = None if _radii == '' else cast(float, _radii)
         _selection = data['atom_selection']
         selection = None if _selection == '' else _selection
-        if isinstance(data['precision'], str):
+        if isinstance(data['precision'], str) or data['precision'].dtype.type is np.str_:
             precision = Precision(data['precision'])
         elif isinstance(data['precision'], Precision):
             precision = data['precision']
         else:
             precision = Precision.DEFAULT
             print("Warning: Invalid precision value, using default")
-        if isinstance(data['atom_shape'], str):
+        if isinstance(data['atom_shape'], str) or data['precision'].dtype.type is np.str_:
             atom_shape = AtomShape(data['atom_shape'])
         elif isinstance(data['atom_shape'], AtomShape):
             atom_shape = data['atom_shape']


### PR DESCRIPTION
With Python 3.10.16 and numpy 2.2.1, when I save parameters, precision and atom_shape are saved as arrays containing strings rather than plain strings. This results in them not being read properly without this fix.

This means that I cannot continue from the make templates step where these parameters are written to the convert images step where they are read as I get an error in `cartesian_phys_to_fourier_polar` about a type mismatch.

Simple code in iPython showing the problem, run inside the example folder:
```
In [1]: import numpy as np

In [2]: from cryolike.stacks.make_templates_from_inputs_api import _make_templates_config

In [3]: from cryolike.microscopy.parameters import load_parameters

In [4]: n_voxels = 132
   ...: voxel_size = 1.346
   ...: precision = 'single'
   ...: viewing_distance = 8.0 / (4.0 * np.pi)
   ...: n_inplanes = 256
   ...: atom_radii = 3.0
   ...: atom_selection = "name CA"

In [5]: atom_shape = 'hard-sphere'

In [6]: resolution_factor = 1.0

In [7]: use_protein_residue_model = True

In [8]: output_plots=True

In [9]: folder_output = "./output/templates/"

In [10]:     cfg = _make_templates_config(
    ...:             n_voxels=n_voxels,
    ...:             voxel_size=voxel_size,
    ...:             viewing_distance=viewing_distance,
    ...:             resolution_factor=resolution_factor,
    ...:             precision=precision,
    ...:             n_inplanes=n_inplanes,
    ...:             atom_radii=atom_radii,
    ...:             atom_selection=atom_selection,
    ...:             use_protein_residue_model=use_protein_residue_model,
    ...:             atom_shape=atom_shape,
    ...:             output_plots=output_plots,
    ...:             folder_output=folder_output
    ...:         )
/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/torch/cuda/__init__.py:129: UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version 11060). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org to install a PyTorch version that has been compiled with your version of the CUDA driver. (Triggered internally at ../c10/cuda/CUDAFunctions.cpp:108.)
  return torch._C._cuda_getDeviceCount() > 0
CUDA is not available or not requested, using CPU.
Parameters:
n_voxels: [132 132 132]
voxel_size: [1.346 1.346 1.346]
box_size: [177.672 177.672 177.672]
radius_max: 33.0
dist_radii: 0.25
n_inplanes: 256
precision: Precision.SINGLE
viewing_distance: 0.6366197723675814
atom_radii: 3.0
atom_selection: name CA
use_protein_residue_model: True
atom_shape: AtomShape.HARD_SPHERE

In [11]: params2 = load_parameters("output/templates/parameters.npz")
Warning: Invalid precision value, using default
Warning: Invalid atom shape value, using default

In [12]: data = np.load("output/templates/parameters.npz", allow_pickle=True)

In [1]: data['precision']
Out[12]: array('single', dtype='<U6')

In [13]: data['atom_shape']
Out[13]: array('hard-sphere', dtype='<U11')
```
