### PR TITLE
fix for type mismatch when use_cuda=False: add use_cuda to set_precision to give np types when False

### DIFF
--- a/src/cryolike/microscopy/nufft.py
+++ b/src/cryolike/microscopy/nufft.py
@@ -132,7 +132,7 @@ def cartesian_phys_to_fourier_polar(
 ) -> torch.Tensor:
     use_cuda = _check_cuda_available() and use_cuda
     device = torch.device('cuda' if use_cuda else 'cpu')
-    (torch_float_type, torch_complex_type, _) = set_precision(precision, default=Precision.SINGLE)
+    (torch_float_type, torch_complex_type, _) = set_precision(precision, default=Precision.SINGLE, use_cuda=True)
     eps = set_epsilon(precision, eps)
     if not isinstance(images_phys, torch.Tensor):
         images_phys = torch.tensor(images_phys, dtype = torch_complex_type)
@@ -197,6 +197,9 @@ def cartesian_phys_to_fourier_polar(
         return image_polar
     else:
         images_phys = images_phys.cpu().numpy()
+        (np_float_type, _, _) = set_precision(precision, default=Precision.SINGLE, use_cuda=False)
+        k1 = np.array(k1, dtype = np_float_type)
+        k2 = np.array(k2, dtype = np_float_type)
         if n_images == 1:
             image_polar = nufft2d2_cpu(k1, k2, images_phys, eps = eps, isign = isign)
         else:

--- a/src/cryolike/util/typechecks.py
+++ b/src/cryolike/util/typechecks.py
@@ -41,23 +41,29 @@ def interpret_precision(precision: Precision | str) -> Precision:
     raise ValueError(f'Unknown string-valued precision {precision}')
 
 
-def set_precision(precision: Precision, default: Precision) -> tuple[dtype, dtype, dtype]:
+def set_precision(precision: Precision, default: Precision, use_cuda: bool = True) -> tuple[dtype, dtype, dtype]:
     """Interprets a Precision enum to return the desired dtypes.
 
     Args:
         precision (Precision): Precision to interpret.
         default (Precision): Precision level to use if DEFAULT is requested.
+        use_cuda (bool): Whether to use cuda and hence whether to return torch dtypes.
+            Otherwise, it returns numpy dtypes
 
     Returns:
-        tuple[dtype, dtype, dtype]: Torch float-type, complex-type, and int-type
+        tuple[dtype, dtype, dtype]: Torch or numpy float-type, complex-type, and int-type
     for the requested precision.
     """
     if precision == Precision.DEFAULT:
         precision = default
     if precision == Precision.SINGLE:
-        return (float32, complex64, int32)
+        if use_cuda:
+            return (float32, complex64, int32)
+        return np.float32, np.complex64, np.int32
     elif precision == Precision.DOUBLE:
-        return (float64, complex128, int64)
+        if use_cuda:
+            return (float64, complex128, int64)
+        return np.float64, np.complex128, np.int64
     else:
         raise ValueError("Unreachable: unrecognized precision type.")
 


### PR DESCRIPTION
My cuda isn't getting recognised because the driver or pytorch needs updating, so this revealed this error to me, which I have now fixed.

```
(cryolike-0.0.1) (base) jkrieger@CNB-WHIPPLE ~/software/scipion3/software/em/reweighting-0.0.1/cryolike (main) $ cd example/
(cryolike-0.0.1) (base) jkrieger@CNB-WHIPPLE ~/software/scipion3/software/em/reweighting-0.0.1/cryolike/example (main) $ python convert_particle_stacks_example.py 
pixel_size: [1.346 1.346]
Warning: Invalid precision value, using default
Warning: Invalid atom shape value, using default
Parameters:
n_voxels: [132 132 132]
voxel_size: [1.346 1.346 1.346]
box_size: [177.672 177.672 177.672]
radius_max: 33.0
dist_radii: 0.25
n_inplanes: 256
precision: Precision.DEFAULT
viewing_distance: 0.6366197723675814
atom_radii: 3.0
atom_selection: name CA
use_protein_residue_model: True
atom_shape: AtomShape.DEFAULT
Warning: CTF amplitude contrast not found, using default value 0.1
Warning: CTF phase shift not found, using default value 0.0
Warning: CTF B-factor not found, using default value 0.0
Warning: CTF scale factor not found, using default value 1.0
Physical images shape:  torch.Size([483, 132, 132])
/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/torch/cuda/__init__.py:129: UserWarning: CUDA initialization: The NVIDIA driver on your system is too old (found version 11060). Please update your GPU driver by downloading and installing a new version from the URL: http://www.nvidia.com/Download/index.aspx Alternatively, go to: https://pytorch.org to install a PyTorch version that has been compiled with your version of the CUDA driver. (Triggered internally at ../c10/cuda/CUDAFunctions.cpp:108.)
  return torch._C._cuda_getDeviceCount() > 0
Traceback (most recent call last):
  File "/home/jkrieger/software/scipion3/software/em/reweighting-0.0.1/cryolike/example/convert_particle_stacks_example.py", line 9, in <module>
    convert_particle_stacks_from_star_files(
  File "/home/jkrieger/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/convert_particle_stacks/particle_stacks_conversion.py", line 197, in convert_particle_stacks_from_star_files
    _do_image_normalization(im_batch, polar_grid, params.precision)
  File "/home/jkrieger/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/convert_particle_stacks/particle_stacks_conversion.py", line 59, in _do_image_normalization
    im.transform_to_fourier(polar_grid=polar_grid, precision=precision, use_cuda=True)
  File "/home/jkrieger/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/stacks/image.py", line 371, in transform_to_fourier
    self.images_fourier = cartesian_phys_to_fourier_polar(
  File "/home/jkrieger/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/microscopy/nufft.py", line 205, in cartesian_phys_to_fourier_polar
    image_polar[i,:] = nufft2d2_cpu(k1, k2, images_phys[i], eps = eps, isign = isign)
  File "/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/finufft/_interfaces.py", line 825, in nufft2d2
    return invoke_guru(2,2,x,y,None,out,None,None,None,f,isign,eps,None,**kwargs)
  File "/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/finufft/_interfaces.py", line 561, in invoke_guru
    out = plan.execute(f,c)
  File "/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/finufft/_interfaces.py", line 249, in execute
    _data = _ensure_array_type(data, "data", self.dtype)
  File "/home/jkrieger/software/miniconda/envs/cryolike-0.0.1/lib/python3.10/site-packages/finufft/_interfaces.py", line 317, in _ensure_array_type
    raise TypeError(f"Argument `{name}` does not have the correct dtype: {x.dtype} was given, but {dtype} was expected.")
TypeError: Argument `data` does not have the correct dtype: complex64 was given, but complex128 was expected.
```
