### PR TITLE
handle unique defocusAngle

### DIFF
--- a/src/cryolike/convert_particle_stacks/particle_stacks_metadata.py
+++ b/src/cryolike/convert_particle_stacks/particle_stacks_metadata.py
@@ -77,7 +77,7 @@ class _Metadata():
         for param in dataBlock.keys():
             y = dataBlock[param]
             y_unique = np.unique(y)
-            if len(y_unique) == 1:
+            if len(y_unique) == 1 and param != 'DefocusAngle':
                 dataBlock[param] = y_unique[0]
 
         defocusU = dataBlock["DefocusU"]

--- a/src/cryolike/microscopy/ctf.py
+++ b/src/cryolike/microscopy/ctf.py
@@ -104,7 +104,7 @@ class LensDescriptor():
         for param in dataBlock.keys():
             y = dataBlock[param]
             y_unique = np.unique(y)
-            if len(y_unique) == 1:
+            if len(y_unique) == 1 and param != 'DefocusAngle':
                 dataBlock[param] = y_unique[0]
 
         return cls(


### PR DESCRIPTION
I have a star file from my synthetic data (copied below the code with the problem) that has unique defocusAngle of 0. This causes a problem with meta.take_batch as the _ensure_array makes an array with just one value and _batchify can't index it. 

This fix converts it into a float instead if there is only one unique value and does the same for any other data that uses _ensure_array ends up in that situation.
```
In [1]: from cryolike.convert_particle_stacks.particle_stacks_metadata import _Metadata

In [2]: star_file = "Runs/014024_ProtRelionExportParticles/Export/particles_014024.star"

In [3]: meta = _Metadata.from_star_file(star_file, defocus_is_degree=True, phase_shift_is_degree=True)
Warning: CTF phase shift not found, using default value 0.0
Warning: CTF B-factor not found, using default value 0.0
Warning: CTF scale factor not found, using default value 1.0

In [4]: meta.take_range(0,20)
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Cell In[4], line 1
----> 1 meta.take_range(0,20)

File ~/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/convert_particle_stacks/particle_stacks_metadata.py:178, in _Metadata.take_range(self, batch_start, batch_end)
    174 def take_range(self, batch_start: int, batch_end: int):
    175     return _Metadata(
    176         defocusU = _batchify(self.defocusU, batch_start, batch_end),
    177         defocusV = _batchify(self.defocusV, batch_start, batch_end),
--> 178         defocusAngle = _batchify(self.defocusAngle, batch_start, batch_end),
    179         sphericalAberration = _batchify(self.sphericalAberration, batch_start, batch_end),
    180         voltage = _batchify(self.voltage, batch_start, batch_end),
    181         amplitudeContrast = _batchify(self.amplitudeContrast, batch_start, batch_end),
    182         phaseShift = _batchify(self.phaseShift, batch_start, batch_end),
    183         defocus_is_degree = self.defocus_is_degree,
    184         phase_shift_is_degree = self.phase_shift_is_degree,
    185         ctfBfactor = _batchify(self.ctfBfactor, batch_start, batch_end),
    186         ctfScalefactor = _batchify(self.ctfScalefactor, batch_start, batch_end),
    187         cs_files = _batchify(self.cs_files, batch_start, batch_end),
    188         cs_idxs = _batchify(self.cs_files, batch_start, batch_end),
    189         cs_pixel_size = _batchify(self.cs_pixel_size, batch_start, batch_end)
    190     )

File ~/software/scipion3/software/em/reweighting-0.0.1/cryolike/src/cryolike/convert_particle_stacks/particle_stacks_metadata.py:20, in _batchify(d, start, end)
     18 def _batchify(d: T2, start: int, end: int) -> T2:
     19     if isinstance(d, ndarray):
---> 20         return cast(T2, d[start:end])
     21     return d

IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed

In [5]: meta.defocusAngle
Out[5]: array(0.)
```

```
# Star file generated with Scipion

# version 30001

data_optics

loop_
_rlnOpticsGroupName 
_rlnOpticsGroup 
_rlnMicrographOriginalPixelSize 
_rlnVoltage 
_rlnSphericalAberration 
_rlnAmplitudeContrast 
_rlnImageSize 
_rlnImageDimensionality 
_rlnImagePixelSize 
 opticsGroup1   1   1.000000   300.000000   2.700000   0.070000   300   2   1.000000 

# version 30001

data_particles

loop_
_rlnImageId 
_rlnOriginalParticleName 
_rlnImageName 
_rlnDefocusU 
_rlnDefocusV 
_rlnCtfAstigmatism 
_rlnDefocusAngle 
_rlnCtfFigureOfMerit 
_rlnCtfMaxResolution 
_rlnOriginXAngst 
_rlnOriginYAngst 
_rlnOriginZAngst 
_rlnAngleRot 
_rlnAngleTilt 
_rlnAnglePsi 
_rlnOpticsGroup 
 523   000268@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000001@Particles/particles.mrcs   8709.222675   8709.222675   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000   59.104478   70.000000   -0.000000   1 
 528   000271@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000002@Particles/particles.mrcs  19928.277407  19928.277407   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000   85.970149   70.000000   -0.000000   1 
 722   000370@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000003@Particles/particles.mrcs   9089.003368   9089.003368   0.000000   0.000000   0   0   0.000000  -0.000000   -0.000000   20.281690   85.000000    0.000000   1 
1439   000697@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000004@Particles/particles.mrcs  10032.560672  10032.560672   0.000000   0.000000   0   0   0.000000   0.000000    0.000000   78.260870  140.000000   -0.000000   1 
1763   000916@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000005@Particles/particles.mrcs  24257.782534  24257.782534   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000  -170.000000   30.000000    0.000000   1 
1777   000930@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000006@Particles/particles.mrcs  22493.956317  22493.956317   0.000000   0.000000   0   0  -0.000000  -0.000000   -0.000000  -30.000000   30.000000    0.000000   1 
2165   001318@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000007@Particles/particles.mrcs   8791.299077   8791.299077   0.000000   0.000000   0   0   0.000000  -0.000000   -0.000000   32.238806   70.000000    0.000000   1 
2178   001331@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000008@Particles/particles.mrcs  20739.626344  20739.626344   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000  102.089552   70.000000    0.000000   1 
2205   001358@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000009@Particles/particles.mrcs  14254.770823  14254.770823   0.000000   0.000000   0   0   0.000000  -0.000000    0.000000  -112.835821   70.000000    0.000000   1 
2306   001459@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000010@Particles/particles.mrcs  14685.127859  14685.127859   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000   56.571429   80.000000    0.000000   1 
2343   001496@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000011@Particles/particles.mrcs  13581.301668  13581.301668   0.000000   0.000000   0   0   0.000000  -0.000000    0.000000  -113.142857   80.000000    0.000000   1 
2528   001681@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000012@Particles/particles.mrcs  22498.735077  22498.735077   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000  106.478873   95.000000    0.000000   1 
2638   001791@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000013@Particles/particles.mrcs  13967.239206  13967.239206   0.000000   0.000000   0   0   0.000000  -0.000000    0.000000  -51.428571  100.000000   -0.000000   1 
2706   001859@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000014@Particles/particles.mrcs  22660.576955  22660.576955   0.000000   0.000000   0   0   0.000000  -0.000000    0.000000  -57.391304  105.000000    0.000000   1 
2724   001877@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000015@Particles/particles.mrcs  14600.337040  14600.337040   0.000000   0.000000   0   0   0.000000  -0.000000   -0.000000   37.611940  110.000000    0.000000   1 
2807   001960@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000016@Particles/particles.mrcs   7679.724423   7679.724423   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000  127.384615  115.000000    0.000000   1 
2986   002139@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000017@Particles/particles.mrcs  20873.772444  20873.772444   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000  104.727273  130.000000   -0.000000   1 
3011   002164@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000018@Particles/particles.mrcs   7997.980904   7997.980904   0.000000   0.000000   0   0   0.000000  -0.000000    0.000000  -91.636364  130.000000    0.000000   1 
3036   002189@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000019@Particles/particles.mrcs  18326.405203  18326.405203   0.000000   0.000000   0   0   0.000000   0.000000   -0.000000   77.647059  135.000000    0.000000   1 
3150   002303@Runs/004973_XmippProtPreprocessParticles/extra/output_images.mrcs   000020@Particles/particles.mrcs   7515.312252   7515.312252   0.000000   0.000000   0   0  -0.000000  -0.000000    0.000000  -114.146341  145.000000    0.000000   1 

```