### PR TITLE
Copied file conversion updates from upstream.

### DIFF
--- a/src/cryolike/convert_particle_stacks/particle_stacks_converter.py
+++ b/src/cryolike/convert_particle_stacks/particle_stacks_converter.py
@@ -136,6 +136,7 @@ def _get_filenames_and_indices(
         # Now look up the selected image/metadata indices from the cs_idxs field
         # for those entries:
         selected_img_indices = (lens_desc.idxs[original_file_list_indices]).squeeze()
+        selected_img_indices = selected_img_indices.astype(np.int64)
         entry = (mrc_file_path, selected_img_indices, original_file_list_indices)
         mrc_files_with_img_indices.append(entry)
     if len(mrc_files_with_img_indices) == 0:
@@ -486,12 +487,10 @@ class ParticleStackConverter():
 
         Args:
             batch_size (int, optional): Target stack size. Defaults to 1024.
-
             never_combine_input_files (bool, optional): If set, Cryosparc source files will
                 be restacked in the same way as Starfile sources, i.e. one source file will
                 generate one or more output stacks, but no output stack will contain images
                 from multiple source files. Defaults to False.
-
         """
         if len(self.inputs_buffer) == 0:
             print(f"Warning: you must prepare input files before running convert_stacks.")

--- a/src/cryolike/convert_particle_stacks/particle_stacks_wrappers.py
+++ b/src/cryolike/convert_particle_stacks/particle_stacks_wrappers.py
@@ -57,7 +57,8 @@ def convert_particle_stacks_from_star_files(
         pixel_size=pixel_size,
         downsample_factor=downsample_factor,
         downsample_type=downsample_type,
-        flag_plots=flag_plots
+        flag_plots=flag_plots,
+        overwrite=overwrite
     )
     converter.prepare_star_files(
         particle_file_list=particle_file_list,
@@ -65,7 +66,7 @@ def convert_particle_stacks_from_star_files(
         defocus_angle_is_degree=defocus_angle_is_degree,
         phase_shift_is_degree=phase_shift_is_degree
     )
-    converter.convert_stacks(batch_size=batch_size, overwrite=overwrite)
+    converter.convert_stacks(batch_size=batch_size)
 
 
 def convert_particle_stacks_from_indexed_star_files(


### PR DESCRIPTION
This pulls in an upstream change to the way the `overwrite` flag is handled for image file conversion, which should be relevant to a reported issue.