### PR TITLE
Benchmarking script for cross_correlation_likelihood

### DIFF
--- a/benchmark/benchmark_cross_correlation_likelihood.py
+++ b/benchmark/benchmark_cross_correlation_likelihood.py
@@ -1,0 +1,97 @@
+from numpy import pi
+import torch
+from torch.testing import assert_close
+import time
+
+from cryolike.cross_correlation_likelihood import CrossCorrelationLikelihood, conform_ctf
+from cryolike.util import (
+    CrossCorrelationReturnType,
+    Precision,
+)
+
+from benchmark_fixtures import (
+    parameters,
+    make_batch_size_params,
+    make_n_pixels_params,
+    make_n_displacements_params,
+    make_mock_polar_grid,
+    make_mock_viewing_angles,
+    make_mock_ctf,
+    make_mock_templates
+)
+
+
+def benchmark_cross_correlation(params: parameters):
+    
+    (torch_float_type, _, _) = params.precision.get_dtypes(default=Precision.SINGLE)
+    polar_grid = make_mock_polar_grid(params.n_pixels)
+    viewing_angles = make_mock_viewing_angles(params.n_templates, params.precision)
+    ctf = make_mock_ctf(polar_grid, True, params.precision)
+    templates = make_mock_templates(polar_grid, viewing_angles, params.precision)
+    images = templates.to_images()
+
+    print(f"Running benchmark with case: ")
+    print(f"  n_pixels: {params.n_pixels}")
+    print(f"  n_templates: {params.n_templates}")
+    print(f"  n_displacements_x: {params.n_displacements_x}")
+    print(f"  n_displacements_y: {params.n_displacements_y}")
+    print(f"  n_templates_per_batch: {params.n_templates_per_batch}")
+    print(f"  n_images_per_batch: {params.n_images_per_batch}")
+    print(f"  precision: {params.precision}")
+    print(f"  device: {params.device}")
+    
+    ####
+    cc = CrossCorrelationLikelihood(
+        templates = templates,
+        max_displacement = 1.0,
+        n_displacements_x = params.n_displacements_x,
+        n_displacements_y = params.n_displacements_y,
+        precision = params.precision,
+        device = params.device,
+        verbose = False
+    )
+    _t_start = time.time()
+    res = cc._compute_cross_correlation_likelihood(
+        device=torch.device(params.device),
+        images_fourier = images.images_fourier,
+        ctf=ctf.ctf,
+        n_pixels_phys = params.n_pixels*params.n_pixels,
+        n_templates_per_batch=params.n_templates_per_batch,
+        n_images_per_batch=params.n_images_per_batch,
+        return_type=CrossCorrelationReturnType.OPTIMAL_POSE,
+        return_integrated_likelihood=False,
+    )#
+    _t_end = time.time()
+    _t_ms = (_t_end - _t_start) * 1000
+    print(f"  Time taken: {_t_ms:.2f} ms")
+
+    torch.cuda.empty_cache()
+    return _t_ms
+    
+
+
+if __name__ == "__main__":
+    if not torch.cuda.is_available():
+        print("CUDA is not available. Exiting.")
+        exit(1)
+    
+    params_batch_size = make_batch_size_params()
+    for params in params_batch_size:
+        torch.cuda.empty_cache()
+        t_ms = benchmark_cross_correlation(params)
+        # print(f"  n_images_per_batch: {params.n_images_per_batch}")
+        # print(f"  n_templates_per_batch: {params.n_templates_per_batch}")
+
+    params_n_pixels = make_n_pixels_params()
+    for params in params_n_pixels:
+        torch.cuda.empty_cache()
+        t_ms = benchmark_cross_correlation(params)
+        # print(f"  n_pixels: {params.n_pixels}")
+    
+    params_n_displacements = make_n_displacements_params()
+    for params in params_n_displacements:
+        torch.cuda.empty_cache()
+        t_ms = benchmark_cross_correlation(params)
+        # print(f"  n_displacements: {params.n_displacements_x * params.n_displacements_y}")
+
+    return

--- a/benchmark/benchmark_fixtures.py
+++ b/benchmark/benchmark_fixtures.py
@@ -1,0 +1,160 @@
+import torch
+import numpy as np
+from unittest.mock import Mock
+
+from scipy.special import jv
+from torch import Tensor
+from numpy import pi
+
+from cryolike.grids import PolarGrid, CartesianGrid2D
+from cryolike.stacks import Templates
+from cryolike.metadata import ViewingAngles
+from cryolike.microscopy import CTF
+
+from cryolike.util import Precision, to_torch
+
+
+class parameters():
+
+    device: str
+    n_pixels: int
+    n_templates: int
+    n_templates_per_batch: int
+    n_images_per_batch: int
+    n_displacements: int
+    precision: Precision
+
+    n_shells: int
+    n_inplanes: int
+
+    def __init__(
+        self,
+        device: str,
+        n_pixels: int,
+        n_templates: int,
+        n_displacements_x: int,
+        n_displacements_y: int,
+        n_templates_per_batch: int,
+        n_images_per_batch: int,
+        precision: Precision,
+    ):
+        self.device = device
+        self.n_pixels = n_pixels
+        self.n_templates = n_templates
+        self.n_displacements_x = n_displacements_x
+        self.n_displacements_y = n_displacements_y
+        self.n_templates_per_batch = n_templates_per_batch
+        self.n_images_per_batch = n_images_per_batch
+        self.precision = precision
+
+
+    def duplicate(self, *,
+        device: str | None = None,
+        n_pixels: int | None = None,
+        n_templates: int | None = None,
+        n_templates_per_batch: int | None = None,
+        n_images_per_batch: int | None = None,
+        n_displacements_x: int | None = None,
+        n_displacements_y: int | None = None,
+        precision: Precision | None = None
+    ):
+        return parameters(
+            device=device if device is not None else self.device,
+            n_pixels=n_pixels if n_pixels is not None else self.n_pixels,
+            n_templates=n_templates if n_templates is not None else self.n_templates,
+            n_displacements_x=n_displacements_x if n_displacements_x is not None else self.n_displacements_x,
+            n_displacements_y=n_displacements_y if n_displacements_y is not None else self.n_displacements_y,
+            n_templates_per_batch=n_templates_per_batch if n_templates_per_batch is not None else self.n_templates_per_batch,
+            n_images_per_batch=n_images_per_batch if n_images_per_batch is not None else self.n_images_per_batch,
+            precision=precision if precision is not None else self.precision,
+        )
+
+
+    @staticmethod
+    def default():
+        return parameters(
+            device='cuda',
+            n_pixels=64,
+            n_templates=1024,
+            n_displacements_x=8,
+            n_displacements_y=8,
+            n_templates_per_batch=256,
+            n_images_per_batch=256,
+            precision=Precision.SINGLE,
+        )
+
+    
+
+
+def make_batch_size_params() -> list[parameters]:
+    params = [parameters.default()]
+    with_image_batch_sizes = [x.duplicate(n_images_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
+    params.extend(with_image_batch_sizes)
+    with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
+    params.extend(with_template_batch_sizes)
+    return params
+
+
+def make_n_pixels_params() -> list[parameters]:
+    params = [parameters.default()]
+    with_n_pixels = [x.duplicate(n_pixels=i) for i in [64, 128, 256, 512, 1024] for x in params]
+    params.extend(with_n_pixels)
+    return params
+
+
+def make_n_displacements_params() -> list[parameters]:
+    params = [parameters.default()]
+    with_n_displacements = [x.duplicate(n_displacements_x=i,n_displacements_y=i) for i in [4, 8, 16, 32] for x in params]
+    params.extend(with_n_displacements)
+    return params
+
+
+
+def make_mock_polar_grid(n_pixels: int) -> PolarGrid:
+    radius_max = n_pixels / (2.0 * pi) * pi / 2.0
+    dist_radii = 0.5 / (2.0 * pi) * pi / 2.0
+    n_inplanes = n_pixels * 4
+    polar_grid = PolarGrid(
+        radius_max = radius_max,
+        dist_radii = dist_radii,
+        n_inplanes = n_inplanes,
+        uniform = True,
+        return_cartesian = True
+    )
+    return polar_grid
+
+
+def make_mock_viewing_angles(n_im: int, precision: Precision = Precision.SINGLE) -> ViewingAngles:
+    (torch_float_type, _, _) = precision.get_dtypes(default=Precision.SINGLE)
+    azimus = torch.linspace(0, 2 * np.pi, n_im, dtype=torch_float_type)
+    polars = torch.linspace(0, np.pi, n_im, dtype=torch_float_type)
+    gammas = torch.linspace(0, 2 * np.pi, n_im, dtype=torch_float_type)
+    return ViewingAngles(azimus, polars, gammas)
+
+
+def make_mock_ctf(polar_grid: PolarGrid, anisotropy: bool = False, precision: Precision = Precision.SINGLE) -> CTF:
+    _radius_shells = to_torch(polar_grid.radius_shells, precision, "cuda")
+    _ctf_tensor = _radius_shells.unsqueeze(0)
+    if anisotropy:
+        _ctf_tensor = _ctf_tensor.unsqueeze(-1).expand(-1, -1, polar_grid.n_inplanes)
+    ctf = CTF(
+        ctf_descriptor=_ctf_tensor,
+        polar_grid=polar_grid,
+        box_size=2.0,
+        anisotropy=anisotropy,
+        cs_corrected=False
+    )
+    return ctf
+
+
+def make_mock_templates(polar_grid: PolarGrid, viewing_angles: ViewingAngles, precision: Precision = Precision.SINGLE) -> Templates:
+    def _mock_function(x: Tensor) -> Tensor:
+        return torch.amax(x, dim=-1) + torch.amin(x, dim=-1) * 1j
+    templates = Templates.generate_from_function(
+        function=_mock_function,
+        viewing_angles=viewing_angles,
+        polar_grid=polar_grid,
+        precision=precision,
+        use_cuda=True
+    )
+    return templates


### PR DESCRIPTION
See benchmark folder for benchmaking script for cross_correlation_likelihood

List of parameters used for the benchmark is set in benchmark.fixtures.py

Run benchmark_cross_correlation_likelihood to perform the test. GPU is required.

Also pulled some necessary changes on the module code (cross_correlation_likelihood.py and ctf.py) from other version to here... 