### PR TITLE
Update LensDescriptor to accept floats as well as ndarrays for ref_pixel_size field

### DIFF
--- a/src/cryolike/metadata/lens_descriptor.py
+++ b/src/cryolike/metadata/lens_descriptor.py
@@ -2,7 +2,15 @@ import numpy as np
 from typing import Any, NamedTuple, Literal
 from pydantic import BaseModel, ConfigDict
 
-from cryolike.util import FloatArrayType, IntArrayType, to_float_flatten_np_array, extract_unique_float
+from cryolike.util import (
+    FloatArrayType,
+    IntArrayType,
+    to_float_flatten_np_array,
+    extract_unique_float,
+    ensure_positive,
+    project_descriptor,
+    TargetType
+)
 from .star_file import read_star_file
 
 
@@ -104,7 +112,7 @@ class LensDescriptor():
     angleRotation: FloatArrayType | None
     angleTilt: FloatArrayType | None
     anglePsi: FloatArrayType | None
-    ref_pixel_size: FloatArrayType | None
+    ref_pixel_size: FloatArrayType | float | None
     files: np.ndarray | None
     idxs: IntArrayType | None
     ctfBfactor: float | FloatArrayType | None
@@ -185,6 +193,9 @@ class LensDescriptor():
         self.angleRotation = angleRotation
         self.angleTilt = angleTilt
         self.anglePsi = anglePsi
+        if ref_pixel_size is not None:
+            ensure_positive(ref_pixel_size, "pixel size")
+            ref_pixel_size = project_descriptor(ref_pixel_size, "pixel size", 2, TargetType.FLOAT)
         self.ref_pixel_size = ref_pixel_size
         self.files = files
         self.idxs = idxs

--- a/src/cryolike/run_likelihood_batch.py
+++ b/src/cryolike/run_likelihood_batch.py
@@ -264,7 +264,7 @@ def run_likelihood_batch(
         images_phys = torch.load(os.path.join(folder_particles_phys, f'particles_phys_stack_{i_stack:06}.pt'), weights_only=True)
         phys_image_data = PhysicalImages(images_phys, pixel_size=image_desc.cartesian_grid.pixel_size)
         im_phys = Images(phys_data=phys_image_data, fourier_data=None)
-        log_likelihood_optimal_pose_physical_images_ = calc_distance_optimal_templates_vs_physical_images(
+        log_likelihood_optimal_pose_physical_images_ = calc_likelihood_optimal_pose(
             template = tp,
             image = im_phys,
             ctf = ctf,

--- a/src/cryolike/util/reformatting.py
+++ b/src/cryolike/util/reformatting.py
@@ -108,8 +108,7 @@ def project_descriptor(descriptor: descriptor_types, label: str, dims: int, targ
 
     # TODO: Typing contravariant stuff.
     if np.isscalar(descriptor):
-        assert isinstance(descriptor, (int, float))
-        result = project_scalar(descriptor, dims)
+        result = project_scalar(descriptor, dims) # type: ignore
     else:
         assert isinstance(descriptor, (list, np.ndarray))
         result = project_vector(descriptor, dims, label)


### PR DESCRIPTION
This fixes an error experienced when the parent `LensDescriptor` has a scalar (native Python) float for the `ref_pixel_size` field. Without this annotation, Pydantic validation would fail when serializing the parent into the buffer. As a result, `convert_particle_stacks` calls would fail after emitting only a single stack.

I've also corrected a reference (in an unused branch) to a function that no longer exists. (Practically this should have no effect, as that code path will hit a fatal error anyway, but it bothered me.)