### PR TITLE
Benchmark changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,7 @@ html/
 # profiling output
 profile.html
 profile.json
+
+# benchmarking output
+benchmark_output/
+profiler_output/

--- a/benchmark/benchmark_cross_correlation_likelihood.py
+++ b/benchmark/benchmark_cross_correlation_likelihood.py
@@ -1,6 +1,6 @@
 import torch
 import torch.profiler as profiler
-import time, os
+import time
 from pathlib import Path
 
 from cryolike.cross_correlation_likelihood import CrossCorrelationLikelihood
@@ -38,7 +38,6 @@ def benchmark_cross_correlation(params: Parameters):
     print(f"  device: {params.device}")
     
     try:
-        ####
         _t_start = time.time()
         cc = CrossCorrelationLikelihood(
             templates = templates,
@@ -70,13 +69,15 @@ def benchmark_cross_correlation(params: Parameters):
                 return_integrated_likelihood=False,
             )
         ## save profiler trace
-        prof.export_chrome_trace(os.path.join(logdir_profiler, "trace.json"))
+        tracefile = logdir_profiler / "trace.json"
+        prof.export_chrome_trace(str(tracefile))
         print(prof.key_averages(group_by_input_shape=True).table(sort_by="cuda_memory_usage", row_limit=20))
         ####
         exit()
-        _t_end = time.time()
-        _t_ms = (_t_end - _t_start) * 1000
-        print(f"  Time taken: {_t_ms:.2f} ms")
+        ## NOTE: THIS CODE IS UNREACHABLE. Is this intended?
+        # # # _t_end = time.time()
+        # # # _t_ms = (_t_end - _t_start) * 1000
+        # # # print(f"  Time taken: {_t_ms:.2f} ms")
     except RuntimeError as e:
         if "CUDA out of memory" in str(e):
             print(f"CUDA out of memory error: {e}")

--- a/benchmark/benchmark_fixtures.py
+++ b/benchmark/benchmark_fixtures.py
@@ -104,9 +104,7 @@ def make_batch_size_params() -> list[Parameters]:
     params = [Parameters.default()]
     with_image_batch_sizes = [x.duplicate(n_images_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
     params.extend(with_image_batch_sizes)
-    # TODO CHANGE BACK
-    # with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
-    with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64] for x in params]
+    with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
     params.extend(with_template_batch_sizes)
     return params
 

--- a/benchmark/benchmark_fixtures.py
+++ b/benchmark/benchmark_fixtures.py
@@ -1,13 +1,13 @@
 import torch
 import numpy as np
-from unittest.mock import Mock
 import pickle
+from pathlib import Path
 
-from scipy.special import jv
 from torch import Tensor
+import numpy as np
 from numpy import pi
 
-from cryolike.grids import PolarGrid, CartesianGrid2D
+from cryolike.grids import PolarGrid
 from cryolike.stacks import Templates
 from cryolike.metadata import ViewingAngles
 from cryolike.microscopy import CTF
@@ -88,7 +88,7 @@ class Parameters:
         )
 
 
-    def save(self, filename: str):
+    def save(self, filename: Path):
         with open(filename, 'wb') as f:
             pickle.dump(self, f)
 
@@ -104,7 +104,9 @@ def make_batch_size_params() -> list[Parameters]:
     params = [Parameters.default()]
     with_image_batch_sizes = [x.duplicate(n_images_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
     params.extend(with_image_batch_sizes)
-    with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
+    # TODO CHANGE BACK
+    # with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024] for x in params]
+    with_template_batch_sizes = [x.duplicate(n_templates_per_batch=i) for i in [1, 2, 4, 8, 16, 32, 64] for x in params]
     params.extend(with_template_batch_sizes)
     return params
 
@@ -124,7 +126,7 @@ def make_n_displacements_params() -> list[Parameters]:
 
 
 
-def make_mock_polar_grid(n_pixels: int) -> PolarGrid:
+def make_default_polar_grid(n_pixels: int) -> PolarGrid:
     radius_max = n_pixels / (2.0 * pi) * pi / 2.0
     dist_radii = 0.5 / (2.0 * pi) * pi / 2.0
     n_inplanes = n_pixels * 4
@@ -138,7 +140,7 @@ def make_mock_polar_grid(n_pixels: int) -> PolarGrid:
     return polar_grid
 
 
-def make_mock_viewing_angles(n_im: int, precision: Precision = Precision.SINGLE) -> ViewingAngles:
+def make_default_viewing_angles(n_im: int, precision: Precision = Precision.SINGLE) -> ViewingAngles:
     (torch_float_type, _, _) = precision.get_dtypes(default=Precision.SINGLE)
     azimus = torch.linspace(0, 2 * np.pi, n_im, dtype=torch_float_type)
     polars = torch.linspace(0, np.pi, n_im, dtype=torch_float_type)
@@ -146,7 +148,7 @@ def make_mock_viewing_angles(n_im: int, precision: Precision = Precision.SINGLE)
     return ViewingAngles(azimus, polars, gammas)
 
 
-def make_mock_ctf(polar_grid: PolarGrid, anisotropy: bool = False, precision: Precision = Precision.SINGLE) -> CTF:
+def make_default_ctf(polar_grid: PolarGrid, anisotropy: bool = False, precision: Precision = Precision.SINGLE) -> CTF:
     _radius_shells = to_torch(polar_grid.radius_shells, precision, "cuda")
     _ctf_tensor = _radius_shells.unsqueeze(0)
     if anisotropy:
@@ -161,11 +163,11 @@ def make_mock_ctf(polar_grid: PolarGrid, anisotropy: bool = False, precision: Pr
     return ctf
 
 
-def make_mock_templates(polar_grid: PolarGrid, viewing_angles: ViewingAngles, precision: Precision = Precision.SINGLE) -> Templates:
-    def _mock_function(x: Tensor) -> Tensor:
+def make_default_templates(polar_grid: PolarGrid, viewing_angles: ViewingAngles, precision: Precision = Precision.SINGLE) -> Templates:
+    def _generator_function(x: Tensor) -> Tensor:
         return torch.amax(x, dim=-1) + torch.amin(x, dim=-1) * 1j
     templates = Templates.generate_from_function(
-        function=_mock_function,
+        function=_generator_function,
         viewing_angles=viewing_angles,
         polar_grid=polar_grid,
         precision=precision,

--- a/src/cryolike/util/enums.py
+++ b/src/cryolike/util/enums.py
@@ -46,7 +46,7 @@ class Precision(Enum):
 
         Returns:
             tuple[dtype, dtype, dtype]: Torch float-type, complex-type, and int-type
-        for the requested precision.
+                for the requested precision.
         """
         if default == Precision.DEFAULT:
             raise ValueError("The 'default' parameter cannot also be Default: you must say what the default is.")

--- a/src/cryolike/util/reformatting.py
+++ b/src/cryolike/util/reformatting.py
@@ -10,11 +10,11 @@ class TargetType(Enum):
     FLOAT = 2
 
 
-def project_scalar(scalar: int | float | np.int_ | np.float_, dims: int) -> IntArrayType | FloatArrayType:
+def project_scalar(scalar: int | float | np.int_ | np.float64 | np.float32, dims: int) -> IntArrayType | FloatArrayType:
     """Returns a numpy array of appropriate dtype and dimension from a scalar input.
 
     Args:
-        scalar (int | float | np.int_ | np.float_): The value to project to an array
+        scalar (int | float | np.int_ | np.float64 | np.float32): The value to project to an array
         dims (int): Dimension (1d) of the desired array
 
     Returns:


### PR DESCRIPTION
A few suggested changes.

Minor ones:
- Renaming `mock` names in the fixtures, which aren't actually mocking anything
- Using `pathlib` instead of `os.path`
- Fixed a bug in the type annotation for `project_scalar` that was referring to a pre-numpy-2.0 type name
- Added profiling/benchmarking outputs to gitignore

Bigger:
I see that as written, there's an `exit()` statement in the `benchmark_cross_correlation` function that terminates overall execution after only one iteration. Plus we no longer report anything with the `time` module.

Is this intended to be the final state? If so, we should remove the code that's no longer reachable, and the unused start time and `time` module itself.