### PR TITLE
Import run-likelihood batch size discovery changes from EMPM PR 96.

### DIFF
--- a/docs/source/concepts/likelihoodComputation.rst
+++ b/docs/source/concepts/likelihoodComputation.rst
@@ -68,7 +68,7 @@ Both wrapper functions take the following parameters:
  - Number of templates and images to use per batch, and whether to
    attempt to determine
    those values automatically (``n_templates_per_batch``,
-   ``n_images_per_batch``, ``estimate_batch_size``)
+   ``n_images_per_batch``, ``discover_batch_size``)
 
 The file manager is provided by the
 :py:func:`cryolike.run_likelihood.configure_likelihood_files` function, and

--- a/example/run_likelihood_example.py
+++ b/example/run_likelihood_example.py
@@ -25,6 +25,6 @@ for i_template in range(2):
         skip_exist = False,
         n_templates_per_batch = 16,
         n_images_per_batch = 64,
-        estimate_batch_size = False,
+        discover_batch_size = False,
         return_likelihood_integrated_pose_fourier = True
     )

--- a/src/cryolike/run_likelihood.py
+++ b/src/cryolike/run_likelihood.py
@@ -1,18 +1,22 @@
 from torch import cuda, device, Tensor, cuda
 from typing import Callable, Literal
+from math import ceil
+import torch
 
 from cryolike.file_mgmt import LikelihoodFileManager, LikelihoodOutputDataSources
 from cryolike.stacks import Templates, Images
 from cryolike.microscopy import CTF
 from cryolike.likelihoods.likelihood import calc_likelihood_optimal_pose
 from cryolike.likelihoods import (
-    OptimalPoseReturn,
+    GeneratorType,
     compute_optimal_pose,
     compute_cross_correlation_complete,
     template_first_comparator
 )
 from cryolike.metadata import ImageDescriptor
 from cryolike.util import  OutputConfiguration, Precision
+
+T_PoseKernel = Callable[[GeneratorType, Templates, Images, CTF, Precision, OutputConfiguration], LikelihoodOutputDataSources]
 
 
 def configure_likelihood_files(
@@ -84,6 +88,165 @@ def configure_displacement(
     return template_grid_setter
 
 
+def _get_smallest_batch(working_val: int, max_items: int):
+    """Returns the smallest batch size that results in the same
+    number of batches as the known-working size.
+
+    The rationale is there's no point using larger batch sizes
+    that result in the same number of batches; if you have a
+    remainder, you have a remainder, and the larger batch size
+    will only risk needless OOM situations and down-estimation.
+
+    Args:
+        working_val (int): A batch size known or believed to work
+        max_items (int): The total number of items being batched
+
+    Returns:
+        int: The smallest batch size resulting in the same batch count.
+    """
+    if working_val < 1 or max_items < 1:
+        raise ValueError("Pools and batch sizes must be positive.")
+    batches_current = ceil(max_items / working_val)
+    return ceil(max_items / batches_current)
+
+
+class _BatchConfig():
+    """Class that handles batch size estimation.
+
+    Attributes:
+        active (bool): Whether we are doing batch size adaptation; if False,
+            we won't compute anything.
+        last_worked (bool): Whether the last iteration completed successfully.
+            Allows the upward size adjustment to work when getting a new
+            stack, which depends on the current stack image count but
+            shouldn't be run before a successful baseline is set.
+        t_batch (int): Current batch size for templates
+        i_batch (int): Current batch size for images
+        t_total (int): Total templates in the stack (which is constant across
+            all image stacks)
+        i_hard_ceiling (int): Lowest image batch size known to cause failure
+        i_hard_floor (int): Highest image batch size known to work
+        t_hard_ceiling (int): Lowest template batch size known to cause OOM failure
+        t_hard_floor (int): Highest template batch size known to work
+    """
+    active: bool
+    last_worked: bool
+    t_batch: int
+    i_batch: int
+    t_total: int
+    i_hard_ceiling: int
+    i_hard_floor: int
+    t_hard_ceiling: int
+    t_hard_floor: int
+
+    def __init__(self, do_discovery: bool, t_batch: int | None, i_batch: int | None, t_total: int):
+        if not do_discovery and (t_batch is None or i_batch is None):
+            raise ValueError("Must provide concrete batch sizes if not doing discovery")
+        if ((t_batch is not None and t_batch < 1) or (i_batch is not None and i_batch < 1)):
+            raise ValueError("User-proposed batch sizes must be positive, if set.")
+        self.last_worked = False
+        self.active = do_discovery
+        self.t_total = t_total
+        self.t_batch = -1 if t_batch is None else t_batch
+        self.i_batch = -1 if i_batch is None else i_batch
+        self.i_hard_ceiling = -1
+        self.i_hard_floor = 0
+        self.t_hard_ceiling = -1
+        self.t_hard_floor = -1
+
+
+    def guess_initial_batches(self, i_total: int):
+        # Don't overwrite user's explicit guesses for t_batch or i_batch
+        if self.t_batch == -1:
+            self.t_batch = self.t_total
+        if self.i_batch == -1:
+            self.i_batch = max(i_total // 8, 1) # intentionally start small here
+        return
+
+
+    def adjust_batches_up(self, i_total: int):
+        if not self.active:
+            return
+        if not self.last_worked:
+            self.last_worked = True
+            return
+        if self.i_batch <= 0 or self.t_batch <= 0:
+            raise ValueError("Broken assumption: must have had a working batch")
+
+        # we know the current template size worked, so we should never go lower
+        self.t_hard_floor = _get_smallest_batch(self.t_batch, self.t_total)
+        # and if we're already doing full batch, we can't increase it, so just
+        # set the current value as the ceiling.
+        # This depends on us using the same template stack per batch config
+        # (a reasonable assumption); if we could allow other templates/if the
+        # template total were to change, our information would not be as strong
+        # regarding whether this is a true ceiling for even larger stacks.
+        if (self.t_batch >= self.t_total):
+            self.t_hard_ceiling = self.t_batch
+
+        # If we don't have a hard template batch ceiling, we're still discovering
+        # how much we can push it. So adjust that only and return
+        if (self.t_hard_ceiling <= 0):
+            self._find_higher_template_size()
+            return
+
+        self.i_hard_floor = max(self.i_batch, self.i_hard_floor)
+        if self.i_hard_ceiling <= 0:
+            # No information about best possible batch sizes, so
+            # go for broke: see if we can do a single image batch.
+            self.i_batch = i_total
+            return
+ 
+        # By this point we have hard ceilings for everything.
+        # So we aren't adjusting template batch size any more,
+        # and should do binary search on possible image batch sizes.
+        batches_at_ceiling = ceil(i_total / self.i_hard_ceiling)
+        batches_at_current = ceil(i_total / self.i_batch)
+
+        # Only adjust if we might reduce the batch count by doing so
+        if batches_at_ceiling < batches_at_current:
+            self.i_batch = (self.i_hard_ceiling + self.i_batch) // 2
+
+
+    def _find_higher_template_size(self):
+        if not self.active:
+            return
+        curr_batch_count = ceil(self.t_total / self.t_batch)
+        if curr_batch_count < 2:
+            # This can no longer happen, because we're checking the batch
+            # size against the total template size before we enter this fn
+            raise ValueError("Impossible: full batch worked but we didn't set a ceiling.")
+        ballpark_batch_size = ceil(self.t_total / (curr_batch_count - 1))
+        self.t_batch = _get_smallest_batch(ballpark_batch_size, self.t_total)
+
+
+    def adjust_batches_down(self):
+        if not self.active:
+            return
+        self.last_worked = False
+        if self.t_batch == 1 and self.i_batch == 1:
+            raise ValueError("Unfixable: OOM error but both batch sizes are already 1.")
+        if self.t_batch == 1 and self.t_hard_floor <= 0:
+            self.t_hard_ceiling = 1
+            self.t_hard_floor = 1
+
+        # We know that we just ran a batch and it didn't work for OOM reasons.
+        # case 1: We don't know the floor for the template size.
+        # Response: try increasing the batch count by 1.
+        # (We'll stop adjusting template batch size once we find one that works)
+        if (self.t_hard_floor <= 0):
+            self.t_hard_ceiling = self.t_batch
+            self.t_batch = _get_smallest_batch(self.t_batch - 1, self.t_total)
+            return
+        else:
+            # We found a working template size, so we'll only change the image size.
+            # Take half the distance between our current (non-working) value and
+            # the (known-working) floor.
+            self.i_hard_ceiling = self.i_batch
+            self.i_batch = (self.i_batch + self.i_hard_floor) // 2
+            return
+
+
 def run_likelihood_optimal_pose(
     file_config: LikelihoodFileManager,
     params_input: str | ImageDescriptor,
@@ -91,9 +254,9 @@ def run_likelihood_optimal_pose(
     template_index: int = 0,
     n_stacks: int = 1,
     skip_exist: bool = False,
-    n_templates_per_batch: int = 1,
-    n_images_per_batch: int = 128,
-    estimate_batch_size: bool = False,
+    n_templates_per_batch: int | None = None,
+    n_images_per_batch: int | None = None,
+    discover_batch_size: bool = False,
     return_likelihood_optimal_pose_fourier: bool = False,
     return_likelihood_integrated_pose_fourier: bool = False
 ):
@@ -131,16 +294,36 @@ def run_likelihood_optimal_pose(
             image stack which appears (from existing file names) to have
             been processed already. Defaults to False.
         n_templates_per_batch (int, optional): The number of templates to
-            try to compare at once in memory. Defaults to 1. Higher numbers
+            try to compare at once in memory. Higher numbers
             should result in more efficient computation, particularly on
             GPUs, but may need to be reduced if out-of-memory errors occur.
+            If set to None (the default), requires discover_batch_size to
+            be set, and will be initially set to the full template count.
         n_images_per_batch (int, optional): The number of images to try to
-            compare at once in memory. Defaults to 128. Higher numbers should
+            compare at once in memory. Higher numbers should
             result in more efficient computation, particularly on GPUs, but
             may need to be reduced if out-of-memory errors occur.
-        estimate_batch_size (bool, optional): Whether to attempt to compute
+            If set to None (the default), requires discover_batch_size to
+            be set, and will be initially guessed as 1/8 of the total images
+            for the first iteration.
+        discover_batch_size (bool, optional): Whether to attempt to compute
             an optimal number of templates and images per batch. Defaults to
-            False. This functionality is not yet very refined.
+            False. If False, explicit template and image batch sizes will be
+            used (and any resulting out-of-memory errors will cause processing
+            failure). If set True, image and template batch sizes will be adjusted
+            for subsequent image stacks with the same template, starting with
+            the values of the n_templates_per_batch and n_images_per_batch
+            parameters (which are taken as hints rather than hard requirements).
+            OOM errors will be caught, and errors will only be generated if
+            the system still runs out of memory with a single image and template
+            per batch. Otherwise, the logic will first adjust the template batch
+            size to the value that gives the smallest total number of template
+            batches without running out of memory. Once this value is found,
+            the image batch size will be adjusted by halves between a hard
+            ceiling (a batch size that resulted in OOM) and a hard floor (the
+            largest known-working batch size), with adjustment stopping once
+            these parameters would no longer decrease the total number of image
+            batches.
         return_likelihood_optimal_pose_fourier (bool, optional): Whether to
             return the optimal Fourier pose (as opposed to the optimal rotation
             and displacement per-template). Defaults to False.
@@ -159,58 +342,27 @@ def run_likelihood_optimal_pose(
         optimized_viewing_angle=True
     )
 
-    (tp, image_desc, _) = file_config.load_template(params_input, template_index)
-    precision = image_desc.precision
-    displacer(tp)
-    optimal_pose_ll_partial = _get_optimal_pose_log_likelihood_partial(tp, precision)
-    file_config.save_displacements(tp.displacement_grid_angstrom)
+    (tp, img_desc, precision) = _prepare_loop(
+        file_config,
+        params_input,
+        displacer,
+        template_index
+    )
 
-    for i_stack in range(n_stacks):
-        if skip_exist and file_config.outputs_exist(i_stack, outputs):
-            # NOTE: this is not a foolproof way to check if the files exist, as the files could be corrupted
-            print(f"Skipping stack number: {i_stack} as all output files already exist")
-            continue
-        (im, ctf) = file_config.load_img_stack(i_stack, image_desc)
+    sizes = _BatchConfig(discover_batch_size, n_templates_per_batch, n_images_per_batch, tp.n_images)
 
-        if estimate_batch_size:
-            n_templates_per_batch, n_images_per_batch = _compute_batch_sizes(tp, im, precision)
-
-        iterator = template_first_comparator(
-            device=device('cuda'),
-            images=im,
-            templates=tp,
-            ctf=ctf,
-            n_images_per_batch=n_images_per_batch,
-            n_templates_per_batch=n_templates_per_batch,
-            return_integrated_likelihood=return_likelihood_integrated_pose_fourier,
-            precision=Precision.DEFAULT
-        )
-
-        out_data = LikelihoodOutputDataSources()
-        optimal_pose, log_likelihood_fourier_integrated = compute_optimal_pose(
-            iterator,
-            tp,
-            im,
-            precision,
-            include_integrated_log_likelihood=True
-        )
-        out_data.optimal_pose = optimal_pose
-        out_data.ll_fourier_integrated = log_likelihood_fourier_integrated
-        if (outputs.optimal_fourier_pose_likelihood):
-            out_data.ll_optimal_fourier_pose = optimal_pose_ll_partial(
-                im,
-                ctf,
-                optimal_pose,
-                "fourier"
-            )
-        if (outputs.optimal_phys_pose_likelihood):
-            raise NotImplementedError
-            im_phys = file_config.load_phys_stack(i_stack, image_desc)
-            out_data.ll_optimal_phys_pose = optimal_pose_ll_partial(im_phys, ctf, optimal_pose, 'phys')
-            del im_phys
-        
-        file_config.write_outputs(i_stack, outputs, out_data)
-        cuda.empty_cache()  # Clear GPU memory after each stack to avoid memory issues
+    _run_stack_loop(
+        n_stacks,
+        skip_exist,
+        file_config,
+        outputs,
+        img_desc,
+        sizes,
+        tp,
+        precision,
+        return_integrated_pose_likelihood_fourier=return_likelihood_integrated_pose_fourier,
+        kernel=_optimal_pose_kernel
+    )
 
 
 def run_likelihood_full_cross_correlation(
@@ -220,9 +372,9 @@ def run_likelihood_full_cross_correlation(
     template_index: int = 0,
     n_stacks: int = 1,
     skip_exist: bool = False,
-    n_templates_per_batch: int = 1,
-    n_images_per_batch: int = 128,
-    estimate_batch_size: bool = False,
+    n_templates_per_batch: int | None = None,
+    n_images_per_batch: int | None = None,
+    discover_batch_size: bool = False,
 ):
     """Function to run cross-correlation likelihood of a template stack against
     potentially several image stacks meeting the same name convention. It is
@@ -255,16 +407,37 @@ def run_likelihood_full_cross_correlation(
             image stack which appears (from existing file names) to have
             been processed already. Defaults to False.
         n_templates_per_batch (int, optional): The number of templates to
-            try to compare at once in memory. Defaults to 1. Higher numbers
+            try to compare at once in memory. Higher numbers
             should result in more efficient computation, particularly on
             GPUs, but may need to be reduced if out-of-memory errors occur.
+            If set to None (the default), requires discover_batch_size to
+            be set, and will be initially set to the full template count.
         n_images_per_batch (int, optional): The number of images to try to
-            compare at once in memory. Defaults to 128. Higher numbers should
+            compare at once in memory. Higher numbers should
             result in more efficient computation, particularly on GPUs, but
             may need to be reduced if out-of-memory errors occur.
-        estimate_batch_size (bool, optional): Whether to attempt to compute
+            If set to None (the default), requires discover_batch_size to
+            be set, and will be initially guessed as 1/8 of the total images
+            for the first iteration.
+        discover_batch_size (bool, optional): Whether to attempt to compute
             an optimal number of templates and images per batch. Defaults to
-            False. This functionality is not yet very refined.
+            False. If False, explicit template and image batch sizes will be
+            used (and any resulting out-of-memory errors will cause processing
+            failure). If set True, image and template batch sizes will be adjusted
+            for subsequent image stacks with the same template, starting with
+            the values of the n_templates_per_batch and n_images_per_batch
+            parameters (which are taken as hints rather than hard requirements).
+            OOM errors will be caught, and errors will only be generated if
+            the system still runs out of memory with a single image and template
+            per batch. Otherwise, the logic will first adjust the template batch
+            size to the value that gives the smallest total number of template
+            batches without running out of memory. Once this value is found,
+            the image batch size will be adjusted by halves between a hard
+            ceiling (a batch size that resulted in OOM) and a hard floor (the
+            largest known-working batch size), with adjustment stopping once
+            these parameters would no longer decrease the total number of image
+            batches.
+
     """
 
     outputs = OutputConfiguration(
@@ -275,129 +448,174 @@ def run_likelihood_full_cross_correlation(
         return_cross_correlation_pose=True
     )
 
+    (tp, img_desc, precision) = _prepare_loop(
+        file_config,
+        params_input,
+        displacer,
+        template_index)
+
+    sizes = _BatchConfig(discover_batch_size, n_templates_per_batch, n_images_per_batch, tp.n_images)
+
+    _run_stack_loop(
+        n_stacks,
+        skip_exist,
+        file_config,
+        outputs,
+        img_desc,
+        sizes,
+        tp,
+        precision,
+        return_integrated_pose_likelihood_fourier=False,
+        kernel=_full_cross_correlation_kernel
+    )
+
+
+def _prepare_loop(
+    file_config: LikelihoodFileManager,
+    params_input: str | ImageDescriptor,
+    displacer: displacement_configurator_T,
+    template_index: int = 0
+):
     (tp, image_desc, _) = file_config.load_template(params_input, template_index)
     precision = image_desc.precision
     displacer(tp)
     file_config.save_displacements(tp.displacement_grid_angstrom)
+    return (tp, image_desc, precision)
 
+
+def _run_stack_loop(
+    n_stacks: int,
+    skip_exist: bool,
+    file_config: LikelihoodFileManager,
+    outputs: OutputConfiguration,
+    image_desc: ImageDescriptor,
+    sizes: _BatchConfig,
+    tp: Templates,
+    precision: Precision,
+    return_integrated_pose_likelihood_fourier: bool,
+    kernel: T_PoseKernel,
+):
     for i_stack in range(n_stacks):
         if skip_exist and file_config.outputs_exist(i_stack, outputs):
             # NOTE: this is not a foolproof way to check if the files exist, as the files could be corrupted
             print(f"Skipping stack number: {i_stack} as all output files already exist")
             continue
         (im, ctf) = file_config.load_img_stack(i_stack, image_desc)
+        total_images = im.n_images
+        sizes.guess_initial_batches(total_images)
+        retry_oom = True
 
-        if estimate_batch_size:
-            n_templates_per_batch, n_images_per_batch = _compute_batch_sizes(tp, im, precision)
+        while(retry_oom):
+            sizes.adjust_batches_up(total_images)
+            print(f"Using batch sizes: {sizes.t_batch} t, {sizes.i_batch} i")
+            iterator = template_first_comparator(
+                device=device('cuda'),
+                images=im,
+                templates=tp,
+                ctf=ctf,
+                n_images_per_batch=sizes.i_batch,
+                n_templates_per_batch=sizes.t_batch,
+                return_integrated_likelihood=return_integrated_pose_likelihood_fourier,
+                precision=precision
+            )
+            try:
+                out_data = kernel(iterator, tp, im, ctf, precision, outputs)
+                file_config.write_outputs(i_stack, outputs, out_data)
+                cuda.empty_cache()
+                retry_oom = False
+            except torch.cuda.OutOfMemoryError:
+                if sizes.active:
+                    sizes.adjust_batches_down()
+                else:
+                    raise
 
-        iterator = template_first_comparator(
-            device=device('cuda'),
-            images=im,
-            templates=tp,
-            ctf=ctf,
-            n_images_per_batch=n_images_per_batch,
-            n_templates_per_batch=n_templates_per_batch,
-            return_integrated_likelihood=False,
-            precision=Precision.DEFAULT
-        )
-        out_data = LikelihoodOutputDataSources()
-        full_cross_correlation_pose = compute_cross_correlation_complete(
-            iterator,
+
+def _get_optimal_pose_log_likelihood(
+    tp: Templates,
+    im: Images,
+    ctf: CTF,
+    precision: Precision,
+    out_data: LikelihoodOutputDataSources,
+    mode: Literal['phys'] | Literal['fourier'] = 'fourier'
+) -> None:
+    if mode == 'phys':
+        raise NotImplementedError
+        ## NOTE: dependency on file config; this needs to be reworked if we
+        ## ever wind up supporting this use case
+        im_phys = file_config.load_phys_stack(i_stack, image_desc)
+        out_data.ll_optimal_phys_pose = partial(im_phys, ctf, optimal_pose, 'phys')
+        del im_phys
+    optimal_pose = out_data.optimal_pose
+    assert optimal_pose is not None
+    res =  calc_likelihood_optimal_pose(
+        template = tp,
+        image = im,
+        ctf = ctf,
+        mode = mode,
+        template_indices = optimal_pose.optimal_template_M,
+        displacements_x = optimal_pose.optimal_displacement_x_M,
+        displacements_y = optimal_pose.optimal_displacement_y_M,
+        inplane_rotations = optimal_pose.optimal_inplane_rotation_M,
+        return_distance = False,
+        return_likelihood = True,
+        precision = precision,
+        use_cuda = True
+    )
+    assert isinstance(res, Tensor)
+    if mode == 'fourier':
+        out_data.ll_optimal_fourier_pose = res
+    if mode == 'phys':
+        out_data.ll_optimal_phys_pose = res
+    return
+
+
+# Note: outputs, ctf are unused but maintain a consistent interface
+# for the other kernel(s).
+def _full_cross_correlation_kernel(
+    iterator: GeneratorType,
+    tp: Templates,
+    im: Images,
+    ctf: CTF,
+    precision: Precision,
+    outputs: OutputConfiguration,
+):
+    out_data = LikelihoodOutputDataSources()
+    full_cross_correlation_pose = compute_cross_correlation_complete(
+        iterator,
+        tp,
+        im,
+        precision,
+        include_integrated_log_likelihood=False
+    )
+    out_data.full_pose = full_cross_correlation_pose
+    return out_data
+
+
+def _optimal_pose_kernel(
+    iterator: GeneratorType,
+    tp: Templates,
+    im: Images,
+    ctf: CTF,
+    precision: Precision,
+    outputs: OutputConfiguration,
+):
+    out_data = LikelihoodOutputDataSources()
+    optimal_pose, log_likelihood_fourier_integrated = compute_optimal_pose(
+        iterator,
+        tp,
+        im,
+        precision,
+        include_integrated_log_likelihood=True
+    )
+    out_data.optimal_pose = optimal_pose
+    out_data.ll_fourier_integrated = log_likelihood_fourier_integrated
+    if outputs.optimal_fourier_pose_likelihood:
+        _get_optimal_pose_log_likelihood(
             tp,
             im,
+            ctf,
             precision,
-            False
+            out_data,
+            'fourier'
         )
-        out_data.full_pose = full_cross_correlation_pose
-        file_config.write_outputs(i_stack, outputs, out_data)
-        cuda.empty_cache()  # Clear GPU memory after each stack to avoid memory issues
-
-
-def _compute_batch_sizes(
-    templates: Templates,
-    images: Images,
-    precision: Precision,
-):
-    if not cuda.is_available():
-        raise ValueError("Requested to estimate batch sizes but no GPU.")
-
-    (torch_float_type, torch_complex_type, _) = Precision.get_dtypes(precision, default=Precision.DOUBLE)
-    n_templates = templates.n_images
-    n_imgs = images.n_images
-    n_shells = templates.polar_grid.n_shells
-    n_inplanes = templates.polar_grid.n_inplanes
-    n_disp = templates.n_displacements
-    
-    size_float = torch_float_type.itemsize ## in bytes
-    size_complex = torch_complex_type.itemsize ## in bytes
-
-    def memory_usage_batchsize(bs_temp: int, bs_img: int) -> int:
-        ## This is a rough estimate of the memory usage for the given batch sizes
-        ## Only consider the significant memory usage
-        
-        _usage = 0
-        # _usage += n_shells * n_inplanes * 8192 * size_complex ## aten::clone
-        # _usage += n_shells * n_inplanes * 8192 * size_complex ## aten::empty_like
-        _usage += bs_temp * n_shells * n_inplanes * size_complex ## sqrtweighted_fourier_templates_mnw
-        _usage += bs_img * n_shells * n_inplanes * size_complex ## images_fourier_snw
-        _usage += bs_temp * n_disp * n_shells * n_inplanes * size_complex ## sqrtweighted_fourier_templates_bessel_mdnq
-        _usage += bs_img * n_shells * n_inplanes * size_complex ## sqrtweighted_image_fourier_bessel_conj_snq
-        _usage += bs_temp * bs_img * n_shells * n_inplanes * size_complex ## CTF_sqrtweighted_fourier_templates_smnw
-        _usage += bs_temp * bs_img * n_disp * n_inplanes * size_complex ## cross_correlation_smdq
-        _usage += bs_temp * bs_img * n_disp * n_inplanes * size_complex ## cross_correlation_smdw
-        _usage += bs_temp * bs_img * n_disp * (n_inplanes // 2 + 1) * size_complex ## aten::_fft_c2r
-        _usage += bs_temp * bs_img * n_disp * n_inplanes * size_complex ## aten::fft_irfft
-
-        return _usage ## in bytes
-
-    free_bytes = cuda.mem_get_info()[0]
-    batch_size_templates = n_templates
-    batch_size_images = n_imgs
-    while(True):
-        _usage = memory_usage_batchsize(batch_size_templates, batch_size_images)
-        if _usage > free_bytes:
-            if batch_size_templates > 1 and batch_size_images > 1:
-                if batch_size_templates > batch_size_images:
-                    batch_size_templates //= 2
-                else:
-                    batch_size_images //= 2
-            elif batch_size_templates > 1:
-                batch_size_templates //= 2
-            elif batch_size_images > 1:
-                batch_size_images //= 2
-            else:
-                raise ValueError("Cannot estimate batch sizes, as both batch sizes are already 1.")
-        else:
-            break
-
-    print(f"Estimated batch sizes: {batch_size_templates} templates, {batch_size_images} images")
-
-    return (batch_size_templates, batch_size_images)
-
-
-
-T_OptPosePartial = Callable[[Images, CTF, OptimalPoseReturn, Literal['phys'] | Literal['fourier']], Tensor]
-def _get_optimal_pose_log_likelihood_partial(tp: Templates, precision: Precision) -> T_OptPosePartial:
-    def _inner(
-        im: Images,
-        ctf: CTF,
-        optimal_pose: OptimalPoseReturn,
-        mode: Literal['phys'] | Literal['fourier'] = 'fourier'
-    ) -> Tensor:
-        res =  calc_likelihood_optimal_pose(
-            template = tp,
-            image = im,
-            ctf = ctf,
-            mode = mode,
-            template_indices = optimal_pose.optimal_template_M,
-            displacements_x = optimal_pose.optimal_displacement_x_M,
-            displacements_y = optimal_pose.optimal_displacement_y_M,
-            inplane_rotations = optimal_pose.optimal_inplane_rotation_M,
-            return_distance = False,
-            return_likelihood = True,
-            precision = precision,
-            use_cuda = True
-        )
-        assert isinstance(res, Tensor)
-        return res
-    return _inner
+    return out_data

--- a/test/unit/test_run_likelihood.py
+++ b/test/unit/test_run_likelihood.py
@@ -1,0 +1,427 @@
+from pytest import mark, raises, skip
+from unittest.mock import Mock, patch
+from math import ceil
+from torch.cuda import OutOfMemoryError, is_available
+
+from cryolike.util import Precision
+
+from cryolike.run_likelihood import (
+    _BatchConfig,
+    _get_smallest_batch,
+    _run_stack_loop
+)
+
+PKG = "cryolike.run_likelihood"
+
+# NOTE: Present testing covers only the batch size discovery behavior.
+# It does not actually assert over likelihood file configuration,
+# displacements, correct configuration for the implemented cross-correlation
+# return types or kernels, or that the run-stack-loop function is calling
+# kernels with correct values.
+
+
+def test_run_stack_loop_skip_exist():
+    if not is_available():
+        skip("Test cannot run because CUDA is not present.")
+    file_conf = Mock()
+    outputs = Mock()
+    image_desc = Mock()
+    sizes = Mock()
+    tp = Mock()
+    kernel = Mock()
+    file_conf.outputs_exist = Mock()
+    assert isinstance(file_conf.outputs_exist, Mock)
+    file_conf.outputs_exist.side_effect = [True, True, False]
+    file_conf.load_img_stack = Mock(return_value=(Mock(), Mock()))
+    assert isinstance(file_conf.load_img_stack, Mock)
+
+    with patch('builtins.print') as _:
+        with patch(f"{PKG}.template_first_comparator") as __:
+            _run_stack_loop(
+                3,
+                True,
+                file_conf,
+                outputs,
+                image_desc,
+                sizes,
+                tp,
+                Precision.DOUBLE,
+                False,
+                kernel
+            )
+            file_conf.write_outputs.assert_called_once()
+            kernel.assert_called_once()
+
+    kernel.reset_mock()
+    file_conf.write_outputs.reset_mock()
+    with patch('builtins.print') as _:
+        with patch(f"{PKG}.template_first_comparator") as __:
+            _run_stack_loop(
+                3,
+                False,
+                file_conf,
+                outputs,
+                image_desc,
+                sizes,
+                tp,
+                Precision.DOUBLE,
+                False,
+                kernel
+            )
+            assert kernel.call_count == 3
+            assert file_conf.write_outputs.call_count == 3
+
+
+def test_run_stack_loop_throws_on_oom_with_no_discovery():
+    file_conf = Mock()
+    outputs = Mock()
+    image_desc = Mock()
+    sizes = _BatchConfig(False, 10, 10, 100)
+    tp = Mock()
+    kernel = Mock(side_effect=OutOfMemoryError)
+    file_conf.load_img_stack = Mock(return_value=(Mock(), Mock()))
+    assert isinstance(file_conf.load_img_stack, Mock)
+
+    with patch('builtins.print') as _:
+        with patch(f"{PKG}.template_first_comparator") as __:
+            with raises(OutOfMemoryError):
+                _run_stack_loop(
+                    3,
+                    False,
+                    file_conf,
+                    outputs,
+                    image_desc,
+                    sizes,
+                    tp,
+                    Precision.DOUBLE,
+                    False,
+                    kernel
+                )
+
+
+def test_run_stack_loop_batch_size_discovery():
+    file_conf = Mock()
+    outputs = Mock()
+    image_desc = Mock()
+    tp = Mock()
+    kernel = Mock()
+    mock_imgs_1 = Mock()
+    mock_imgs_1.n_images = 100
+    mock_imgs_2 = Mock()
+    mock_imgs_2.n_images = 300
+    file_conf.load_img_stack = Mock(side_effect=[(mock_imgs_1, Mock()), (mock_imgs_2, Mock())])
+    assert isinstance(file_conf.load_img_stack, Mock)
+
+    kernel.side_effect = [OutOfMemoryError, Mock(), OutOfMemoryError, Mock()]
+    # With these settings, we expect to wind up with:
+    #  1. Fail: lower template batch size to 5
+    #  2. Succeed: set template batch size bounds
+    #  3. Fail: Set image batch size ceiling = 300
+    #     and image batch to 200
+    #  4. Succeed: End loop
+    sizes = _BatchConfig(True, 10, 100, 10)
+
+    with patch('builtins.print') as _:
+        with patch(f"{PKG}.template_first_comparator") as __:
+            _run_stack_loop(
+                2,
+                False,
+                file_conf,
+                outputs,
+                image_desc,
+                sizes,
+                tp,
+                Precision.DOUBLE,
+                True,
+                kernel
+            )
+            # attempted loop 4x and finished it twice
+            assert kernel.call_count == 4
+            assert file_conf.write_outputs.call_count == 2
+            assert sizes.t_batch == 5
+            assert sizes.t_hard_ceiling == 10
+            assert sizes.t_hard_floor == 5
+            assert sizes.i_batch == 200
+            assert sizes.i_hard_ceiling == 300
+            assert sizes.i_hard_floor == 100
+
+
+@mark.parametrize('total,batch', [
+    (60,19),
+    (60,15),
+    (60,60),
+    (60,120),
+    (60,1)
+])
+def test_get_smallest_batch(total: int, batch: int):
+    batch_count = ceil(total / batch)
+    smallest_batch = _get_smallest_batch(batch, total)
+    new_batch_count = ceil(total / smallest_batch)
+    # three conditions for success:
+    # 1. the proposed value has to result in the same # of batches
+    # 2. A smaller batch value would result in more batches
+    # 3. the proposed value should not exceed the original one
+    
+    assert new_batch_count == batch_count
+    if smallest_batch == 1:
+        return
+    using_lower_batch = ceil(total / (smallest_batch - 1))
+    assert using_lower_batch > batch_count
+    assert smallest_batch <= batch
+
+
+def test_get_smallest_batch_throws_on_negative_values():
+    with raises(ValueError):
+        _get_smallest_batch(0, 4)
+    with raises(ValueError):
+        _get_smallest_batch(3, -2)
+
+
+@mark.parametrize("with_discovery, with_guesses", [(True, False), (False, True)])
+def test_batchconfig_initialization(with_discovery: bool, with_guesses: bool):
+    t_batch = 5 if with_guesses else None
+    i_batch = 7 if with_guesses else None
+
+    sut = _BatchConfig(with_discovery, t_batch, i_batch, 75)
+    assert sut.t_total == 75
+    assert sut.active == with_discovery
+    assert sut.last_worked == False
+    if with_guesses:
+        assert sut.t_batch == t_batch
+        assert sut.i_batch == i_batch
+    else:
+        assert sut.t_batch == -1
+        assert sut.i_batch == -1
+    assert sut.i_hard_floor == 0
+    for x in [sut.i_hard_ceiling, sut.t_hard_ceiling, sut.t_hard_floor]:
+        assert x == -1
+
+
+def test_batchconfig_initialization_throws_on_ambiguous_invocation():
+    with raises(ValueError):
+        _ = _BatchConfig(do_discovery=False, t_batch=15, i_batch=None, t_total=60)
+    with raises(ValueError):
+        _ = _BatchConfig(do_discovery=False, t_batch=None, i_batch=15, t_total=60)
+
+
+def test_batchconfig_initialization_throws_on_nonpositive_batch_sizes():
+    with raises(ValueError):
+        _ = _BatchConfig(True, None, 0, 60)
+    with raises(ValueError):
+        _ = _BatchConfig(True, -3, None, 60)
+
+
+@mark.parametrize("i,t", [(1, 1), (5, None), (None, 10)])
+def test_guess_initial_batches(i: int | None, t: int | None):
+    # Values chosen just to make sure they don't reproduce the actual guess rule
+    t_total = t * 100 if t is not None else 100
+    i_total = i if i is not None else 800
+    sut = _BatchConfig(True, t, i, t_total)
+    sut.guess_initial_batches(i_total)
+
+    # Note: this tests both that we honor the presets and that we
+    # generate guesses
+    if i is not None:
+        assert sut.i_batch == i
+    if t is not None:
+        assert sut.t_batch == t
+    assert sut.i_batch > 0
+    assert sut.t_batch > 0
+
+
+def test_adjust_batches_up_no_op_when_not_discovering():
+    sut = _BatchConfig(False, 1, 1, 1)
+    sut.last_worked = True
+    with patch(f"{PKG}._get_smallest_batch") as fn:
+        sut.adjust_batches_up(40)
+        fn.assert_not_called()
+
+
+def test_adjust_batches_up_no_op_when_failed_last_cycle():
+    sut = _BatchConfig(True, 1, 1, 1)
+    assert not sut.last_worked
+    with patch(f"{PKG}._get_smallest_batch") as fn:
+        sut.adjust_batches_up(40)
+        fn.assert_not_called()
+        assert sut.last_worked
+
+
+def test_adjust_batches_up_throws_on_bad_batches():
+    sut = _BatchConfig(True, 1, 1, 1)
+    sut.last_worked = True
+    # in practice, this shouldn't happen through usual channels
+    sut.i_batch = 0
+    with raises(ValueError):
+        sut.adjust_batches_up(40)
+    sut.i_batch = 1
+    sut.t_batch = -1
+    with raises(ValueError):
+        sut.adjust_batches_up(40)
+
+
+def test_adjust_batches_up_increases_template_size():
+    # These numbers should yield ceil(60/13) = 5 batches.
+    t_count = 60
+    t_batch_initial = 13
+    i_batch_initial = 50
+    sut = _BatchConfig(True, t_batch_initial, i_batch_initial, t_count)
+    with patch(f"{PKG}._get_smallest_batch") as fn:
+        sut.adjust_batches_up(40)
+        fn.assert_not_called()
+    # "last_worked" flag should now be active
+    assert sut.t_hard_floor == -1
+    assert sut.t_hard_ceiling == -1
+
+    sut.adjust_batches_up(40)
+
+    # Floor should be set to 12 (smallest batch yielding 5 batches)
+    # & the new t_batch should be 15, which yields 4 batches.
+    assert sut.t_hard_floor == 12
+    assert sut.t_batch == 15
+    # Confirm we short-circuited adjustments to the image batch size
+    assert sut.i_batch == 50 # the amount passed in the test ctor
+    assert sut.i_hard_floor == 0
+
+
+def test_adjust_batches_up_increases_image_size_without_ceiling():
+    # NOTE: Also tests that we set ceiling to max if full batch worked
+    t_count = 60
+    t_batch_init = 120
+    i_batch_init = 50
+    i_max = 5000
+    sut = _BatchConfig(True, t_batch_init, i_batch_init, t_count)
+    # manually flip the toggle so that we actually do stuff
+    sut.last_worked = True
+
+    # With no i_hard_ceiling, we go for broke and try to use
+    # a full batch for the images.
+    # While we're here, also check that we set template hard
+    # ceiling to the requested batch if a single-run batch size
+    # worked.
+    assert sut.t_hard_ceiling == -1
+    assert sut.i_hard_ceiling == -1
+    sut.adjust_batches_up(i_max)
+    assert sut.t_hard_ceiling >= t_count
+    assert sut.i_batch == i_max
+    assert sut.i_batch > i_batch_init
+
+
+def test_adjust_batches_up_increases_image_size_with_ceiling():
+    t_count = 60
+    t_batch_init = 60
+    i_batch_init = 50
+    i_batch_ceil = 100
+    i_max = 5000
+    sut = _BatchConfig(True, t_batch_init, i_batch_init, t_count)
+    sut.last_worked = True
+    sut.i_hard_ceiling = i_batch_ceil
+
+    sut.adjust_batches_up(i_max)
+    assert sut.i_batch == i_batch_init + (i_batch_ceil - i_batch_init) // 2
+    assert sut.i_batch > i_batch_init
+    assert sut.i_batch < i_max
+
+
+def test_adjust_batches_up_no_op_if_ceiling_precludes_image_increase():
+    t_count = 60
+    t_batch_init = 60
+    i_batch_init = 100
+    i_batch_ceil = 180
+    i_max = 200
+    sut = _BatchConfig(True, t_batch_init, i_batch_init, t_count)
+    sut.last_worked = True
+    sut.i_hard_ceiling = i_batch_ceil
+
+    # numbers above should give 2 batches for either init or ceil size
+    # this should be a no-op for the size increase
+    sut.adjust_batches_up(i_max)
+    assert sut.i_batch == i_batch_init
+
+
+def test_find_higher_template_size_throws_on_full_batch():
+    t_count = 60
+    t_batch = 60
+    sut = _BatchConfig(True, t_batch, None, t_count)
+    with raises(ValueError):
+        sut._find_higher_template_size()
+
+
+def test_find_higher_template_size_no_op_on_inactive():
+    t_count = 60
+    t_batch = 60
+    sut = _BatchConfig(False, t_batch, 5, t_count)
+    # Assert: nothing thrown
+    # (could mock out _get_smallest_batch to assert not called, if feeling pedantic)
+    sut._find_higher_template_size()
+
+
+def test_adjust_batches_down_no_op_when_not_discovering():
+    sut = _BatchConfig(False, 5, 5, 5)
+    sut.last_worked = True  # use as signal that we have no-oped
+    sut.adjust_batches_down()
+    # Because the first step of actual batch down-adjustment is to
+    # set this flag, this serves as a check that we did no-op
+    assert sut.last_worked
+
+
+def test_adjust_batches_down_throws_if_cannot_go_lower():
+    sut = _BatchConfig(True, 1, 1, 5)
+    with raises(ValueError, match="Unfixable"):
+        sut.adjust_batches_down()
+
+
+def test_adjust_batches_down_lowers_t_batch_if_no_floor():
+    t_count = 60
+    t_batch = t_count // 4
+    i_batch = 1
+    sut = _BatchConfig(True, t_batch, i_batch, t_count)
+    sut.last_worked = True
+
+    assert sut.t_batch == t_batch
+    assert sut.t_hard_floor < 0
+    sut.adjust_batches_down()
+    assert sut.last_worked == False
+    assert sut.t_hard_ceiling == t_batch
+    assert sut.t_batch < t_batch
+    assert sut.t_batch == t_count // 5
+
+
+def test_adjust_batches_down_sets_bounds_if_t_is_one():
+    t_count = 60
+    t_batch = 1
+    i_batch = 10
+    sut = _BatchConfig(True, t_batch, i_batch, t_count)
+
+    assert sut.t_hard_floor <= 0
+    assert sut.t_hard_ceiling <= 0
+    sut.adjust_batches_down()
+    assert sut.t_hard_ceiling == 1
+    assert sut.t_hard_floor == 1
+    assert sut.i_batch <= i_batch
+
+
+def test_adjust_batches_down_lowers_i_batch_if_t_has_floor():
+    t_count = 60
+    t_batch = 15
+    i_batch = 100
+    sut = _BatchConfig(True, t_batch, i_batch, t_count)
+    sut.t_hard_floor = t_batch
+
+    assert sut.i_hard_ceiling == -1
+    sut.adjust_batches_down()
+
+    assert sut.i_hard_ceiling == i_batch
+    assert sut.i_batch == i_batch // 2
+
+
+def test_adjust_batches_down_lowers_i_if_both_have_floor():
+    t_count = 60
+    t_batch = 15
+    i_batch = 100
+    i_floor = 50
+    sut = _BatchConfig(True, t_batch, i_batch, t_count)
+    sut.t_hard_floor = t_batch
+    sut.i_hard_floor = i_floor
+
+    sut.adjust_batches_down()
+    assert sut.i_batch == (i_batch + i_floor) // 2


### PR DESCRIPTION
As per https://github.com/flatironinstitute/EMPM/pull/96

Quoted:
This PR brings the automatic batch size feature back into EMPM/CryoLike. I had adjusted it to estimate batch sizes instead of doing discovery (which was based on a loop and catching OOM errors). However, the estimation did not work correctly, and empirically it didn't seem correctable since the relationship between batch size and memory usage was highly nonlinear.

I've reinstated a "catch OOM errors and shrink batch size" loop, but with more sophistication for how the batch sizes are estimated (which includes avoiding recomputation with known-bad batch sizes when we have known-good ones). Specifically:

- We can now take the user-requested batch sizes as a starting place or hint for batch sizes.
- We optimize for template batch size first, since templates are the outer loop in the currently implemented cross-correlation jobs.
  - For templates, while we have not discovered a working template count, we choose batch sizes that increment the total number of batches by 1. (So, for instance, if we had 60 templates and found that a batch size of 15 didn't work, we would next try 12, since 60/15 is 4 batches, and 12 is the smallest batch size that gets us 5 batches.)
  - Once the template batch size is set, we try to do full-batch for the images. We track image batch size floor and ceiling, and adapt by moving to halfway between the current batch size and the floor or ceiling (depending on whether we failed or succeeded).
 - We stop adapting image batch sizes when the current and new proposals would result in the same batch count.

I've rerun the automated tests and confirmed that the example still works, so I'll commit this update to CryoLike directly.
